### PR TITLE
Create config property "omitSemicolon"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $ npm install --save csharp-models-to-typescript
         "locale": "en-US"
     },
     "numericEnums": false,
+    "omitSemicolon": false,
     "stringLiteralTypesInsteadOfEnums": false,
     "customTypeTranslations": {
         "ProductName": "string",

--- a/converter.js
+++ b/converter.js
@@ -70,12 +70,14 @@ const createConverter = config => {
         rows.push(`// ${filename}`);
         rows.push(`export interface ${model.ModelName}${baseClasses} {`);
 
+        const propertySemicolon = config.omitSemicolon ? '' : ';';
+
         if (model.IndexSignature) {
-            rows.push(`    ${convertIndexType(model.IndexSignature)};`);
+            rows.push(`    ${convertIndexType(model.IndexSignature)}${propertySemicolon}`);
         }
 
         members.forEach(member => {
-            rows.push(`    ${convertProperty(member)};`);
+            rows.push(`    ${convertProperty(member)}${propertySemicolon}`);
         });
 
         rows.push(`}\n`);

--- a/converter.js
+++ b/converter.js
@@ -95,11 +95,13 @@ const createConverter = config => {
             ? camelcase(value)
             : value;
 
+        const lastValueSemicolon = config.omitSemicolon ? '' : ';';
+
         if (config.stringLiteralTypesInsteadOfEnums) {
             rows.push(`export type ${enum_.Identifier} =`);
 
             entries.forEach(([key], i) => {
-                const delimiter = (i === entries.length - 1) ? ';' : ' |';
+                const delimiter = (i === entries.length - 1) ? lastValueSemicolon : ' |';
                 rows.push(`    '${getEnumStringValue(key)}'${delimiter}`);
             });
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ const converter = createConverter({
     camelCaseOptions: config.camelCaseOptions || {},
     camelCaseEnums: config.camelCaseEnums || false,
     numericEnums: config.numericEnums || false,
+    omitSemicolon: config.omitSemicolon || false,
     stringLiteralTypesInsteadOfEnums: config.stringLiteralTypesInsteadOfEnums || false
 });
 


### PR DESCRIPTION
Some projects don't use semicolons in javascript files.

A setting for this avoids having to open the generated file and apply code formatting to remove the semicolons.

If the name `omitSemicolon` for this configuration is not good, I welcome suggestions.